### PR TITLE
New release: 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*/target
-*/probes
+**/target
 */.idea
 Cargo.lock

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
+
 # Breezy timer ⏲️
 
 Breezy timer's objective is to be a very simple timing library, which can be put into 
 production code without changing the final performance. See section 
 [how does it work](#how-does-it-work) for further information.
+
+[![](https://img.shields.io/crates/v/breezy-timer.svg)](https://crates.io/crates/breezy-timer)
+[![](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://docs.rs/breezy-timer/latest/breezy_timer/)
 
 ## Aim
 - simple to use

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ sum of the durations of all previous ones.
 - Add GlobalBreezyTimer, together with function based timing using 
 procedural macro and a global BreezyTimer
 - Check performance gain with simpler hasher (by default, `HashMap` uses DOS-safe hasher) 
+- Add `stop_start("foo", "bar")` function to easily stop timer `foo` and start `bar`
 
 ## License
 

--- a/benches/performance_benchmarks.rs
+++ b/benches/performance_benchmarks.rs
@@ -3,10 +3,6 @@
 use criterion::{criterion_group, criterion_main, Criterion, BenchmarkId, black_box};
 use breezy_timer::*;
 use std::mem::take;
-use global::Global;
-
-prepare_timer!();
-
 
 fn sum_normal(vec: &Vec<u8>, iterations: usize) -> u32 {
     let mut total = 0;
@@ -19,13 +15,14 @@ fn sum_normal(vec: &Vec<u8>, iterations: usize) -> u32 {
 }
 
 fn sum_timed(vec: &Vec<u8>, iterations: usize) -> u32 {
+    let mut btimer = BreezyTimer::new();
     let mut total = 0;
     for _ in 0..iterations {
-        start_timer!("sum");
+        btimer.start("sum");
         for v in black_box(vec) {
             total += *v as u32
         }
-        stop_timer!("sum");
+        btimer.stop("sum");
     }
     total
 }
@@ -47,13 +44,13 @@ fn bench_sum(c: &mut Criterion) {
 }
 
 fn start_and_stop_timer(name: &'static str) {
-    start_timer!(name);
-    stop_timer!(name);
+    let mut btimer = BreezyTimer::new();
+    btimer.start(name);
+    btimer.stop(name);
 }
 
 fn bench_timer(c: &mut Criterion) {
     // size: number of times to sum the vector
-    prepare_timer!();
     c.bench_with_input(BenchmarkId::new("start and stop timer", &"foo"),
                        &"foo",|b, name| b.iter(|| start_and_stop_timer(name)) );
 

--- a/benches/performance_benchmarks.rs
+++ b/benches/performance_benchmarks.rs
@@ -2,7 +2,6 @@
 
 use criterion::{criterion_group, criterion_main, Criterion, BenchmarkId, black_box};
 use breezy_timer::*;
-use std::mem::take;
 
 fn sum_normal(vec: &Vec<u8>, iterations: usize) -> u32 {
     let mut total = 0;

--- a/breezy-timer-lib/Cargo.toml
+++ b/breezy-timer-lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "breezy-timer"
+name = "breezy-timer-lib"
 version = "1.0.0"
 authors = ["Ed <barp.edoardo@gmail.com>"]
 edition = "2018"
@@ -10,22 +10,10 @@ description = "Painless and production friendly timers"
 repository = "https://github.com/dominusmi/rust-breezy-timer"
 exclude = [".idea"]
 readme = "README.md"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 cpu-time = "1.0.0"
-global = "0.4.3"
-breezy-timer-lib = { path = "breezy-timer-lib" }
-
-
-[dev-dependencies]
-criterion = "0.3.4"
-rand = "0.8.3"
-
-[[bench]]
-name = "performance_benchmarks"
-harness = false
 
 [features]
-breezy_timer = ["breezy-timer-lib/breezy_timer"]
+"breezy_timer" = []

--- a/breezy-timer-lib/src/lib.rs
+++ b/breezy-timer-lib/src/lib.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+use cpu_time::ProcessTime;
+use std::time::Duration;
+
+pub type BreezyTimer = HashMap<&'static str, TimerState>;
+
+/// Structure used to keep track of the current process time since the last `start_timer!()` call,
+/// as well as the sum of all previously calculated times.
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct TimerState {
+    process_time: ProcessTime,
+    total_elapsed: Duration
+}
+
+impl TimerState {
+    pub fn new() -> Self {
+        TimerState {
+            process_time: ProcessTime::now(),
+            total_elapsed: Duration::new(0, 0)
+        }
+    }
+
+    /// Helper function to add time up to a certain ProcessTime
+    pub fn add_time(&mut self, up_to: ProcessTime){
+        self.total_elapsed += up_to.duration_since(self.process_time);
+    }
+
+    /// Setter function to reset time to the given ProcessTime
+    pub fn reset_time(&mut self, new_time: ProcessTime){
+        self.process_time = new_time;
+    }
+
+    pub fn get_total_elapsed(&self) -> Duration {
+        self.total_elapsed.clone()
+    }
+}
+
+pub trait Timer {
+    /// Creates or updates a timer with the provided name. The same timer can be started and stopped
+    /// as many times as needed, and will keep track of the sum of all the time spent
+    fn start(&mut self, _: &'static str) { return }
+
+    /// Stops the timer with the provided name. The timer must already exist, or this call will panic.
+    /// The same timer can be started and stopped as many times as needed, and will keep track of the
+    /// sum of all the intervals
+    fn stop(&mut self, _: &'static str) { return }
+
+    fn elapsed(&self, _: &'static str) -> Option<Duration> { return None }
+}
+
+impl Timer for HashMap<&'static str, TimerState> {
+    #[cfg(feature="breezy_timer")]
+    fn start(&mut self, name: &'static str) {
+        self.entry(name)
+        .and_modify(|entry| entry.reset_time(ProcessTime::now()))
+        .or_insert(TimerState::new());
+    }
+
+    #[cfg(feature="breezy_timer")]
+    fn stop(&mut self, name: &'static str) {
+        let before = ProcessTime::now();
+        match self.get_mut(name) {
+            // todo: is there no better way than this?
+            //  problem with using the `log` crate is that the logger must be initialised upstream,
+            //  which is  a big assumption. Given that the feature should not be active for production
+            //  environment but only development, a print seems fair enough?
+            None => println!("Warning: timer {} was stopped but does not exist", name),
+            Some(entry) => {
+                entry.add_time(before);
+            }
+        }
+    }
+
+    #[cfg(feature="breezy_timer")]
+    fn elapsed(&self, name: &'static str) -> Option<Duration> {
+        match self.get(&name) {
+            None => None,
+            Some(ts) => Some(ts.total_elapsed)
+        }
+    }
+}

--- a/examples/basic_example.rs
+++ b/examples/basic_example.rs
@@ -1,4 +1,3 @@
-use cpu_time::ProcessTime;
 use criterion::black_box;
 
 use breezy_timer::{prepare_timer, start_timer, stop_timer, elapsed_ns, get_timers_map};

--- a/examples/basic_example.rs
+++ b/examples/basic_example.rs
@@ -1,30 +1,27 @@
 use criterion::black_box;
-
-use breezy_timer::{prepare_timer, start_timer, stop_timer, elapsed_ns, get_timers_map};
-
-prepare_timer!();
+use breezy_timer_lib::{BreezyTimer, Timer};
 
 fn main(){
+    let mut btimer = BreezyTimer::new();
     let mut vectors = Vec::new();
 
-    start_timer!("total");
+    btimer.start("total");
     for _ in 0..10 {
-        start_timer!("allocations");
+        btimer.start("allocations");
         let vec: Vec<u8> = (0..102400).map(|_| { rand::random::<u8>() }).collect();
         vectors.push(vec);
-        stop_timer!("allocations");
+        btimer.stop("allocations");
 
-        start_timer!("sum");
+        btimer.start("sum");
         let mut total = 0;
         for v in vectors.iter() {
             total += v.iter().map(|x| *x as u32).sum::<u32>();
         }
         // used so that compiler doesn't simply remove the loop because nothing is done with total
         black_box(total);
-        stop_timer!("sum");
+        btimer.stop("sum");
     }
-    stop_timer!("total");
+    btimer.stop("total");
 
-    println!("{:?}", get_timers_map!());
-    println!("allocations: {}ns\nsum: {}ns\ntotal: {}ns", elapsed_ns!("allocations"), elapsed_ns!("sum"), elapsed_ns!("total"));
+    println!("{:?}", btimer);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,201 +1,84 @@
-pub use std::collections::HashMap;
-pub use global::Global;
+pub use breezy_timer_lib::{TimerState, BreezyTimer, Timer};
+
 pub use cpu_time::ProcessTime;
-use std::hash::Hash;
+pub use std::collections::HashMap;
 
-/// Structure used to keep track of the current process time since the last `start_timer!()` call,
-/// as well as the sum of all previously calculated times.
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct TimerState {
-    process_time: ProcessTime,
-    total_ns: u128
-}
-
-impl TimerState {
-    pub fn new() -> Self {
-        TimerState {
-            process_time: ProcessTime::now(),
-            total_ns: 0
-        }
-    }
-
-    /// Helper function to add time up to a certain ProcessTime
-    pub fn add_time(&mut self, up_to: ProcessTime){
-        self.total_ns += up_to.duration_since(self.process_time).as_nanos();
-    }
-
-    /// Setter function to reset time to the given ProcessTime
-    pub fn reset_time(&mut self, new_time: ProcessTime){
-        self.process_time = new_time;
-    }
-
-    /// Getter function to the total_ns variable
-    pub fn get_total_elapsed_ns(&self) -> u128 {
-        self.total_ns
-    }
-}
-
-/// Prepares the global variable `TIMERS`. Must be called before any other macro from this crate,
-/// or the other calls will panic
-#[macro_export]
-macro_rules! prepare_timer {
-    () => {
-            #[cfg(feature="breezy_timer")]
-            static TIMERS: $crate::Global<std::collections::HashMap<&'static str, $crate::TimerState>> = $crate::Global::new();
-    }
-}
-
-/// Creates or updates a timer with the provided name. The same timer can be started and stopped
-/// as many times as needed, and will keep track of the sum of all the time spent
-#[macro_export]
-macro_rules! start_timer {
-    ( $x:expr ) => {
-        #[cfg(feature="breezy_timer")]
-        {
-            TIMERS.with_mut(|hashmap| {
-                hashmap.entry($x)
-                    .and_modify(|entry| entry.reset_time($crate::ProcessTime::now()))
-                    .or_insert($crate::TimerState::new());
-            });
-        }
-    };
-}
-
-/// Stops the timer with the provided name. The timer must already exist, or this call will panic.
-/// The same timer can be started and stopped as many times as needed, and will keep track of the
-/// sum of all the time spent
-#[macro_export]
-macro_rules! stop_timer {
-    ( $x:expr ) => {
-        #[cfg(feature="breezy_timer")]
-        {
-            let before = cpu_time::ProcessTime::now();
-            TIMERS.with_mut(|hashmap| {
-                let entry = hashmap.get_mut($x).unwrap();
-                entry.add_time(before);
-            });
-        }
-    };
-}
-
-/// Returns the amount of nanoseconds elapsed by the timer with the provided name. If feature
-/// `breezy_timer` is not active, returns 0 (to avoid breaking code which depends on the output)
-#[macro_export]
-macro_rules! elapsed_ns {
-    ( $x:expr) => {
-        {
-            #[cfg(feature="breezy_timer")]
-            {
-                TIMERS.with(|hashmap| hashmap[$x].get_total_elapsed_ns())
-            }
-
-            #[cfg(not(feature="breezy_timer"))]
-            {
-                0u128
-            }
-        }
-    }
-}
-
-/// Helper function to clone a hashmap, needed by the macro `get_timers_map!()`
-pub fn clone_hashmap<A: Clone+Eq+Hash, B: Clone+Eq>(hashmap: &HashMap<A, B>) -> HashMap<A, B> {
-    let mut new_hashmap = HashMap::new();
-    for (a,b) in hashmap.iter(){
-        new_hashmap.insert(a.clone(), b.clone());
-    }
-    new_hashmap
-}
-
-/// Returns the hashmap containing each timer. The key corresponds to the timer name, and the value
-/// is an instance of `TimerState`. If feature `breezy_timer` is not active, return an empty
-/// `HashMap` (to avoid breaking code which depends on the output)
-#[macro_export]
-macro_rules! get_timers_map {
-    () => {
-        {
-            #[cfg(feature="breezy_timer")]
-            {
-                TIMERS.with(|hashmap| $crate::clone_hashmap(hashmap))
-            }
-            #[cfg(not(feature="breezy_timer"))]
-            {
-                use std::collections::HashMap;
-                HashMap::<&'static str, $crate::TimerState>::new()
-            }
-        }
-    }
-}
 
 #[cfg(all(test, feature="breezy_timer"))]
 mod tests {
     use cpu_time::ProcessTime;
     use criterion::black_box;
+    use std::collections::HashMap;
+    use breezy_timer_lib::{BreezyTimer, TimerState, Timer};
 
     #[test]
     fn check() {
-        prepare_timer!();
+        let mut btimer = BreezyTimer::new();
 
         let start = ProcessTime::now();
-        start_timer!("loop");
-        assert!(TIMERS.lock().unwrap().contains_key("loop"));
+        btimer.start("loop");
+
+        assert!(btimer.contains_key("loop"));
         let mut total = 0;
         for _ in 0..100 {
             total += black_box(1);
         }
         black_box(total);
-        stop_timer!("loop");
+        btimer.stop("loop");
+
         let elapsed_ns = start.elapsed().as_nanos();
 
-        let elapsed_macro = elapsed_ns!("loop");
-        assert!(elapsed_macro > 0);
-        assert!(elapsed_macro < elapsed_ns);
+        let elapsed_breezy = btimer.elapsed("loop");
+        assert!(elapsed_breezy.is_some());
+        let elapsed_breezy = elapsed_breezy.unwrap().as_nanos();
+
+        assert!(elapsed_breezy > 0);
+        assert!(elapsed_breezy < elapsed_ns);
     }
 
     #[test]
     fn sanity_check(){
+        let mut btimer = BreezyTimer::new();
+
         let mut vectors = Vec::new();
 
-        prepare_timer!();
-        start_timer!("total");
+        btimer.start("total");
         for _ in 0..10 {
-            start_timer!("allocations");
+            btimer.start("allocations");
             let vec: Vec<u8> = (0..102400).map(|_| { rand::random::<u8>() }).collect();
             vectors.push(vec);
-            stop_timer!("allocations");
+            btimer.stop("allocations");
 
-            start_timer!("sum");
+            btimer.start("sum");
             let mut total = 0;
             for v in vectors.iter() {
                 total += v.iter().map(|x| *x as u32).sum::<u32>();
             }
             // used so that compiler doesn't simply remove the loop because nothing is done with total
             black_box(total);
-            stop_timer!("sum");
+            btimer.stop("sum");
         }
-        stop_timer!("total");
-        assert!(elapsed_ns!("allocations") < elapsed_ns!("total"));
-        assert!(elapsed_ns!("sum") < elapsed_ns!("total"))
+        btimer.stop("total");
+        assert!(btimer.elapsed("allocations").unwrap() < btimer.elapsed("total").unwrap());
+        assert!(btimer.elapsed("sum").unwrap() < btimer.elapsed("total").unwrap())
     }
 }
 
 #[cfg(all(test, not(feature="breezy_timer")))]
 mod tests {
-    use cpu_time::ProcessTime;
     use criterion::black_box;
+    use breezy_timer_lib::{BreezyTimer, Timer};
 
     #[test]
     fn check_no_feature() {
-        prepare_timer!();
-
-        let start = ProcessTime::now();
-        start_timer!("loop");
+        let mut btimer = BreezyTimer::new();
+        btimer.start("loop");
         let mut total = 0;
         for _ in 0..100 {
-            total += black_box(1);
+            total += 1;
         }
-        stop_timer!("loop");
-        let elapsed_ns = start.elapsed().as_nanos();
-        let elapsed_macro = elapsed_ns!("loop");
-        assert!(elapsed_macro == 0);
+        black_box(total);
+        btimer.stop("loop");
+        assert!(btimer.elapsed("loop").is_none());
     }
 }


### PR DESCRIPTION
- move away from macro use since it's not needed and make code less transparent
- as a result, the timer is not global anymore, but is a variable like every other
- removal of global means a big improvement in performance
- main source code moved to `breezy-timer-lib` crate. This is preparing for the use of procedural macros for breezy function timing